### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Extension Installer
-by NGMS#3914 & @otnkmk8d & @reactor-coding
+by NGMS#3914 & [@otnkmk8d](https://github.com/otnkmk8d) & [@reactor-coding](https://github.com/reactor-coding)
 
 ©2023 MJUC
 
@@ -7,7 +7,7 @@ Chrome拡張機能をインストールするためのブックマークレッ�
 
 ## 使い方
 
-①最新版（https://github.com/otnkmk8d/Extension-Installer/releases/） をダウンロードし、コードを全てコピー
+①最新版（[Latest Releases](https://github.com/otnkmk8d/Extension-Installer/releases/)） をダウンロードし、コードを全てコピー
 
 ②任意のサイトでCtrl+D
 
@@ -15,10 +15,10 @@ Chrome拡張機能をインストールするためのブックマークレッ�
 
 ④"URL"にJavascriptのコードをペーストし、保存（名前は任意）
 
-⑤https://chrome.google.com/webstorex にアクセスし、作成したブックマークレットを使用
+⑤[https://chrome.google.com/webstorex](https://chrome.google.com/webstorex) にアクセスし、作成したブックマークレットを使用
 
-⑥入力欄にダウンロードしたい拡張機能のURL（https://chrome.google.com/webstore/detail/ から始まるもの）またはIDを入力
+⑥入力欄にダウンロードしたい拡張機能のURL（[https://chrome.google.com/webstore/detail/](https://chrome.google.com/webstore/detail/) から始まるもの）または 拡張機能IDを入力
 
 ⑦"Download"ボタンを押し、アラートの"拡張機能を追加"を押す 
 
-※"Extension ID is Invalid!"とアラートが出た場合は、拡張機能IDまたはURLが無効です
+※ "Extension ID is Invalid!" とアラートが出た場合は、拡張機能IDまたはURLが無効です


### PR DESCRIPTION
`①最新版（[https://github.com/otnkmk8d/Extension-Installer/releases/）](https://github.com/otnkmk8d/Extension-Installer/releases/%EF%BC%89) をダウンロードし、コードを全てコピー`
のところが「https://github.com/otnkmk8d/Extension-Installer/releases/）」という"）"がついたリンクとなってしまっていたところの修正

`またはIDを入力`
のところの付け足し「または**拡張機能**IDを入力」

`@otnkmk8d` 及び `@reactor-coding` のところをリンク化しました